### PR TITLE
Fix file naming during download

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ and converts the transcripts into colour-coded SRT subtitle files.
 The repository currently contains a minimal GUI with a working downloader pane.
 Downloads are performed using `yt-dlp` and saved into the `downloads/` folder by
 default. Ensure that the `yt-dlp` executable is installed and available on your
-`PATH` so the application can invoke it.
+`PATH` so the application can invoke it. `ffmpeg` is required by `yt-dlp` for
+audio extraction, so install the system `ffmpeg` binary and verify that it is
+accessible on your `PATH`. The Python wrapper `ffmpeg-python` is listed in
+`requirements.txt` but it still relies on the external `ffmpeg` executable.
 
 ## Installation
 

--- a/dreamwatch/downloader.py
+++ b/dreamwatch/downloader.py
@@ -43,7 +43,8 @@ def download_audio(video_id: str, dst: Path) -> None:
 
     dst.mkdir(parents=True, exist_ok=True)
     url = f"https://www.youtube.com/watch?v={video_id}"
-    output_tpl = str(dst / "%(_id)s.%(ext)s")
+    # use the video ID for a unique filename
+    output_tpl = str(dst / "%(id)s.%(ext)s")
     cmd = [
         "yt-dlp",
         "-f",

--- a/dreamwatch/gui.py
+++ b/dreamwatch/gui.py
@@ -29,8 +29,7 @@ class DownloaderWidget(QWidget):
         url_row = QHBoxLayout()
         url_row.addWidget(QLabel("Playlist/URL:"))
         self.url_edit = QLineEdit()
-        # validate URL as the user types
-        self.url_edit.textChanged.connect(self._check_url)
+        # only validate once the user finishes editing
         self.url_edit.editingFinished.connect(self._check_url)
         url_row.addWidget(self.url_edit)
         self.url_status = QLabel()
@@ -58,14 +57,19 @@ class DownloaderWidget(QWidget):
 
         dst_row = QHBoxLayout()
         dst_row.addWidget(QLabel("Destination:"))
-        self.dst_edit = QLineEdit(str(Path("downloads") / "NewProject"))
+        self.dst_edit = QLineEdit("")
+        self.dst_edit.editingFinished.connect(self._check_url)
+        auto_btn = QPushButton("Auto Name")
+        auto_btn.clicked.connect(self._auto_name)
         browse = QPushButton("Browse")
         browse.clicked.connect(self._browse)
         dst_row.addWidget(self.dst_edit)
+        dst_row.addWidget(auto_btn)
         dst_row.addWidget(browse)
         layout.addLayout(dst_row)
 
         self.download_btn = QPushButton("Download")
+        self.download_btn.setEnabled(False)
         self.download_btn.clicked.connect(self._start_download)
         layout.addWidget(self.download_btn)
 
@@ -75,21 +79,44 @@ class DownloaderWidget(QWidget):
         folder = QFileDialog.getExistingDirectory(self, "Select download folder")
         if folder:
             self.dst_edit.setText(folder)
+            self._check_url()
 
-    def _check_url(self) -> None:
-        """Validate the URL and update destination if valid."""
+    def _auto_name(self) -> None:
+        """Set destination based on playlist title."""
 
         url = self.url_edit.text().strip()
         if not url:
-            self.url_status.setText("")
             return
         valid, folder = validate_url(url)
+        if not valid:
+            self.url_status.setText("\u274c")
+            self.download_btn.setEnabled(False)
+            return
+        # sanitize for Windows
+        name = (folder or "NewProject")
+        invalid = '<>:"/\\|?*'
+        name = "".join(ch for ch in name if ch not in invalid)
+        name = name.replace(" ", "")
+        proj_dir = Path("downloads") / name
+        self.dst_edit.setText(str(proj_dir))
+        self._check_url()
+
+    def _check_url(self) -> None:
+        """Validate the URL if a destination folder is provided."""
+
+        url = self.url_edit.text().strip()
+        dst = self.dst_edit.text().strip()
+        if not url or not dst:
+            self.url_status.setText("")
+            self.download_btn.setEnabled(False)
+            return
+        valid, _ = validate_url(url)
         if valid:
             self.url_status.setText("\u2705")  # check mark
-            proj_dir = Path("downloads") / (folder or "NewProject")
-            self.dst_edit.setText(str(proj_dir))
+            self.download_btn.setEnabled(True)
         else:
             self.url_status.setText("\u274c")  # red cross
+            self.download_btn.setEnabled(False)
 
     def _start_download(self) -> None:
         """Trigger download using parameters from the form."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PySide6
 yt-dlp
+ffmpeg-python


### PR DESCRIPTION
## Summary
- correct filename template so yt-dlp uses each video's ID
- clarify ffmpeg requirement in README

## Testing
- `python -m py_compile dreamwatch/gui.py dreamwatch/downloader.py`
- `pytest -q` *(fails: command not found)*